### PR TITLE
[REFACTOR] RestClient 빈 등록 후 baseUrl, defaultHeader 추가

### DIFF
--- a/src/main/java/open/api/coc/external/coc/clan/ClanApiServiceImpl.java
+++ b/src/main/java/open/api/coc/external/coc/clan/ClanApiServiceImpl.java
@@ -20,14 +20,11 @@ import org.springframework.web.client.RestClient;
 public class ClanApiServiceImpl implements open.api.coc.external.coc.clan.ClanApiService {
 
     private final ClashOfClanConfig clashOfClanConfig;
-
+    private final RestClient restClient;
     @Override
     @SuppressWarnings("unchecked")
     public Map<String, Object> findClanByClanTag(String clanTag) {
-        return RestClient.create()
-                         .get()
-                         .uri(clashOfClanConfig.getClansClanTagUri(), clanTag)
-                         .header("Authorization", "Bearer " + clashOfClanConfig.getApiKey())
+        return restClient.get().uri(clashOfClanConfig.getClansClanTagUri(), clanTag)
                          .retrieve()
                          .body(Map.class);
     }
@@ -35,30 +32,24 @@ public class ClanApiServiceImpl implements open.api.coc.external.coc.clan.ClanAp
     @Override
     public Optional<ClanCapitalRaidSeasons> findClanCapitalRaidSeasonsByClanTagAndLimit(String clanTag, int limit) {
         String uri = clashOfClanConfig.getClansClanTagCapitalRaidSeasonsUri() + "?limit=" + limit;
-        return Optional.ofNullable(RestClient.create()
-                                             .get()
+        return Optional.ofNullable(restClient.get()
                                              .uri(uri, clanTag)
-                                             .header("Authorization", "Bearer " + clashOfClanConfig.getApiKey())
                                              .retrieve()
                                              .body(ClanCapitalRaidSeasons.class));
     }
 
     @Override
     public Optional<ClanWar> findClanCurrentWarByClanTag(String clanTag) {
-        return Optional.ofNullable(RestClient.create()
-                                             .get()
+        return Optional.ofNullable(restClient.get()
                                              .uri(clashOfClanConfig.getClansClanTagCurrentWarUri(), clanTag)
-                                             .header("Authorization", "Bearer " + clashOfClanConfig.getApiKey())
                                              .retrieve()
                                              .body(ClanWar.class));
     }
 
     @Override
     public Optional<ClanMemberList> findClanMembersByClanTag(String clanTag) {
-        return Optional.ofNullable(RestClient.create()
-                                             .get()
+        return Optional.ofNullable(restClient.get()
                                              .uri(clashOfClanConfig.getClansClanMembersUri(), clanTag)
-                                             .header("Authorization", "Bearer " + clashOfClanConfig.getApiKey())
                                              .retrieve()
                                              .body(ClanMemberList.class));
     }
@@ -78,10 +69,8 @@ public class ClanApiServiceImpl implements open.api.coc.external.coc.clan.ClanAp
     }
 
     private Optional<Player> findPlayer(String playTag) {
-        return Optional.ofNullable(RestClient.create()
-                                             .get()
+        return Optional.ofNullable(restClient.get()
                                              .uri(clashOfClanConfig.getPlayerUri(), playTag)
-                                             .header("Authorization", "Bearer " + clashOfClanConfig.getApiKey())
                                              .retrieve()
                                              .body(Player.class));
     }

--- a/src/main/java/open/api/coc/external/coc/clan/config/RestClientConfig.java
+++ b/src/main/java/open/api/coc/external/coc/clan/config/RestClientConfig.java
@@ -1,0 +1,22 @@
+package open.api.coc.external.coc.clan.config;
+
+import lombok.RequiredArgsConstructor;
+import open.api.coc.external.coc.config.ClashOfClanConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class RestClientConfig {
+
+    private final ClashOfClanConfig clashOfClanConfig;
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.builder()
+                .baseUrl(clashOfClanConfig.getDomain())
+                .defaultHeader("Authorization", "Bearer " + clashOfClanConfig.getApiKey())
+                .build();
+    }
+}

--- a/src/main/java/open/api/coc/external/coc/config/ClashOfClanConfig.java
+++ b/src/main/java/open/api/coc/external/coc/config/ClashOfClanConfig.java
@@ -54,23 +54,23 @@ public class ClashOfClanConfig {
     }
 
     public String getClansClanTagUri() {
-        return getDomain() + getEndPoint().getClans().getClanTag();
+        return getEndPoint().getClans().getClanTag();
     }
 
     public String getClansClanTagCapitalRaidSeasonsUri() {
-        return getDomain() + getEndPoint().getClans().getCapitalRaidSeasons();
+        return getEndPoint().getClans().getCapitalRaidSeasons();
     }
 
     public String getClansClanTagCurrentWarUri() {
-        return getDomain() + getEndPoint().getClans().getCurrentWar();
+        return getEndPoint().getClans().getCurrentWar();
     }
 
     public String getClansClanMembersUri() {
-        return getDomain() + getEndPoint().getClans().getMembers();
+        return getEndPoint().getClans().getMembers();
     }
 
     public String getPlayerUri() {
-        return getDomain() + getEndPoint().getPlayers().getPlayer();
+        return getEndPoint().getPlayers().getPlayer();
     }
 
 }

--- a/src/main/java/open/api/coc/external/coc/config/RestClientConfig.java
+++ b/src/main/java/open/api/coc/external/coc/config/RestClientConfig.java
@@ -1,7 +1,6 @@
-package open.api.coc.external.coc.clan.config;
+package open.api.coc.external.coc.config;
 
 import lombok.RequiredArgsConstructor;
-import open.api.coc.external.coc.config.ClashOfClanConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;


### PR DESCRIPTION
ClashOfClanConfig getDomain()의 중복, ClanApiServiceImpl의 HTTP 요청마다 Header 값 설정 중복이 있어서 RestClient에 baseUrl, defaultHeader 설정하고 빈으로 등록하였습니다.